### PR TITLE
Fix nuget build

### DIFF
--- a/Ghpr.Core/Ghpr.Core.nuspec
+++ b/Ghpr.Core/Ghpr.Core.nuspec
@@ -19,8 +19,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src=".\bin\Release-NET40\Ghpr.Core.dll" target="lib/net40" />
-    <file src=".\bin\Release-NET452\Ghpr.Core.dll" target="lib/net452" />
+    <file src=".\bin\Release-NET40\Ghpr.Core.dll" target="lib\net40" />
     <file src=".\bin\Release-NET452\Ghpr.Core.Settings.json" target="content" />
   </files>
 </package>


### PR DESCRIPTION
It should work now 😄 

I used slashes instead of backslashes which confused nuget
bin\Release-NET452\Ghpr.Core.dll is added by default it caused a warning
New CI: build https://ci.appveyor.com/project/betrisey/ghpr-core/build/1.0.8

Fixes #35 