### PR TITLE
Update TestRun.cs

### DIFF
--- a/Ghpr.Core/Common/TestRun.cs
+++ b/Ghpr.Core/Common/TestRun.cs
@@ -95,7 +95,7 @@ namespace Ghpr.Core.Common
                 {
                     return TestResult.Inconclusive;
                 }
-                if (Result.Contains("Ignored") || Result.Contains("Skipped"))
+                if (Result.Contains("Ignored") || Result.Contains("Skipped") || Result.Contains("NotExecuted"))
                 {
                     return TestResult.Ignored;
                 }


### PR DESCRIPTION
When skipping tests with MSTest test framework, the result/outcome is stored as **NotExecuted**. I added a condition to catch this so that the tests get marked as **Ignore** instead of **Unknown**.

I can supply a test .trx file if you would like to review further.