### PR TITLE
Fix missing description when building TestRunDto

### DIFF
--- a/Ghpr.Controller.ts/controller/common/localFileSystem/mappers/TestRunDtoMapper.ts
+++ b/Ghpr.Controller.ts/controller/common/localFileSystem/mappers/TestRunDtoMapper.ts
@@ -42,7 +42,7 @@ class TestRunDtoMapper {
         let testRunDto = new TestRunDto();
         testRunDto.name = testRun.name;
         testRunDto.categories = testRun.categories;
-        testRunDto.description = testRunDto.description;
+        testRunDto.description = testRun.description;
         testRunDto.duration = testRun.duration;
         testRunDto.events = eventDtos;
         testRunDto.fullName = testRun.fullName;


### PR DESCRIPTION
### Description

There is a small bug on the TestRunDtoMapper when we're building a testRunDto object from the testRun data.